### PR TITLE
[FEATURE #3]: Spring Dependency Management Plugin 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,24 @@
 plugins {
     id 'java'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'org.example'
 version = '1.0-SNAPSHOT'
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework:spring-framework-bom:6.2.9"
+    }
+}
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
+    implementation 'org.springframework:spring-core'
+    implementation 'org.springframework:spring-context'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }


### PR DESCRIPTION
## 관련 이슈

- #3 

## 변경 사항

- `io.spring.dependency-management:1.1.7` 적용
- `org.springframework:spring-framework-bom:6.2.9` mavenBom 으로 6.2.9 (현재 spring-framework 7버전 이전 최신 버전)으로 Spring 관련 버전 관리 자동화
- `org.springframework:spring-core`,  `org.springframework:spring-context` 종속성 추가 -> 6.2.9 버전 자동 적용 확인