### PR TITLE
[FEATURE #9]: 로깅 라이브러리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.38'
     testCompileOnly 'org.projectlombok:lombok:1.18.38'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.38'
+
+    implementation 'ch.qos.logback:logback-classic:1.5.18'
+    runtimeOnly 'org.apache.logging.log4j:log4j-to-slf4j:2.24.3'
 }
 
 test {


### PR DESCRIPTION
## 관련 이슈

- #9 

## 변경 사항

로깅을 위한 `logback-classic`과 `log4j-to-slf4j` 라이브러리를 추가하였습니다. 별도의 설정 없이 Lombok의 `@Slf4j` 어노테이션으로 로거를 사용할 수 있습니다.

### 예시 코드
```java
@Slf4j
public class LoggingTest {
    public static void main(String[] args) {
        log.info("Hello World");
    }
}
```

### 결과

<img width="489" height="103" alt="image" src="https://github.com/user-attachments/assets/fac12fbf-8625-4bc8-9f16-d062f7917415" />
